### PR TITLE
hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,11 +293,196 @@ Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version numbe
 
 ### Задание 3
 
-`Приведите ответ в свободной форме........`
 
-1. `Заполните здесь этапы выполнения, если требуется ....`
-2. `Заполните здесь этапы выполнения, если требуется ....`
-3. `Заполните здесь этапы выполнения, если требуется ....`
+
+1. `Создал ветку terraform-hotfix`
+2. `Проверка кода tflint и checkov`
+
+```
+tflint
+checkov -d .
+
+```
+3. `Вывод`
+
+```
+alexey@dell:~/team_terraform/vms$ tflint
+2 issue(s) found:
+
+Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)
+
+  on main.tf line 5:
+   5: data "template_file" "cloud_init" {
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.12.0/docs/rules/terraform_required_providers.md
+
+Warning: [Fixable] variable "public_key" is declared but not used (terraform_unused_declarations)
+
+  on variables.tf line 3:
+   3: variable "public_key" {
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.12.0/docs/rules/terraform_unused_declarations.md
+
+alexey@dell:~/team_terraform/vms$ checkov -d .
+[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
+[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml_outputs.tf
+[ terraform framework ]: 100%|████████████████████|[4/4], Current File Scanned=variables.tf           
+[ secrets framework ]: 100%|████████████████████|[5/5], Current File Scanned=./variables.tf           
+
+       _               _
+   ___| |__   ___  ___| | _______   __
+  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
+ | (__| | | |  __/ (__|   < (_) \ V /
+  \___|_| |_|\___|\___|_|\_\___/ \_/
+
+By Prisma Cloud | version: 3.2.441 
+
+terraform scan results:
+
+Passed checks: 2, Failed checks: 4, Skipped checks: 0
+
+Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
+        PASSED for resource: yandex_compute_instance.vm_marketing
+        File: /main.tf:12-40
+Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
+        PASSED for resource: yandex_compute_instance.vm_analytics
+        File: /main.tf:42-70
+Check: CKV_YC_11: "Ensure security group is assigned to network interface."
+        FAILED for resource: yandex_compute_instance.vm_marketing
+        File: /main.tf:12-40
+
+                12 | resource "yandex_compute_instance" "vm_marketing" {
+                13 |   name        = "vm-marketing"
+                14 |   platform_id = "standard-v1"
+                15 |   zone        = "ru-central1-a"  
+                16 | 
+                17 |   resources {
+                18 |     cores  = 2
+                19 |     memory = 2
+                20 |   }
+                21 | 
+                22 |   boot_disk {
+                23 |     initialize_params {
+                24 |       image_id = var.image_id
+                25 |     }
+                26 |   }
+                27 | 
+                28 |   network_interface {
+                29 |     subnet_id = var.subnet_id
+                30 |     nat       = true
+                31 |   }
+                32 | 
+                33 |   metadata = {
+                34 |     user-data = data.template_file.cloud_init.rendered
+                35 |   }
+                36 | 
+                37 |   labels = {
+                38 |     project = "marketing"
+                39 |   }
+                40 | }
+
+Check: CKV_YC_2: "Ensure compute instance does not have public IP."
+        FAILED for resource: yandex_compute_instance.vm_marketing
+        File: /main.tf:12-40
+
+                12 | resource "yandex_compute_instance" "vm_marketing" {
+                13 |   name        = "vm-marketing"
+                14 |   platform_id = "standard-v1"
+                15 |   zone        = "ru-central1-a"  
+                16 | 
+                17 |   resources {
+                18 |     cores  = 2
+                19 |     memory = 2
+                20 |   }
+                21 | 
+                22 |   boot_disk {
+                23 |     initialize_params {
+                24 |       image_id = var.image_id
+                25 |     }
+                26 |   }
+                27 | 
+                28 |   network_interface {
+                29 |     subnet_id = var.subnet_id
+                30 |     nat       = true
+                31 |   }
+                32 | 
+                33 |   metadata = {
+                34 |     user-data = data.template_file.cloud_init.rendered
+                35 |   }
+                36 | 
+                37 |   labels = {
+                38 |     project = "marketing"
+                39 |   }
+                40 | }
+
+Check: CKV_YC_11: "Ensure security group is assigned to network interface."
+        FAILED for resource: yandex_compute_instance.vm_analytics
+        File: /main.tf:42-70
+
+                42 | resource "yandex_compute_instance" "vm_analytics" {
+                43 |   name        = "vm-analytics"
+                44 |   platform_id = "standard-v1"
+                45 |   zone        = "ru-central1-a"
+                46 | 
+                47 |   resources {
+                48 |     cores  = 2
+                49 |     memory = 2
+                50 |   }
+                51 | 
+                52 |   boot_disk {
+                53 |     initialize_params {
+                54 |       image_id = var.image_id
+                55 |     }
+                56 |   }
+                57 | 
+                58 |   network_interface {
+                59 |     subnet_id = var.subnet_id
+                60 |     nat       = true
+                61 |   }
+                62 | 
+                63 |   metadata = {
+                64 |     user-data = data.template_file.cloud_init.rendered
+                65 |   }
+                66 | 
+                67 |   labels = {
+                68 |     project = "analytics"
+                69 |   }
+                70 | }
+
+Check: CKV_YC_2: "Ensure compute instance does not have public IP."
+        FAILED for resource: yandex_compute_instance.vm_analytics
+        File: /main.tf:42-70
+
+                42 | resource "yandex_compute_instance" "vm_analytics" {
+                43 |   name        = "vm-analytics"
+                44 |   platform_id = "standard-v1"
+                45 |   zone        = "ru-central1-a"
+                46 | 
+                47 |   resources {
+                48 |     cores  = 2
+                49 |     memory = 2
+                50 |   }
+                51 | 
+                52 |   boot_disk {
+                53 |     initialize_params {
+                54 |       image_id = var.image_id
+                55 |     }
+                56 |   }
+                57 | 
+                58 |   network_interface {
+                59 |     subnet_id = var.subnet_id
+                60 |     nat       = true
+                61 |   }
+                62 | 
+                63 |   metadata = {
+                64 |     user-data = data.template_file.cloud_init.rendered
+                65 |   }
+                66 | 
+                67 |   labels = {
+                68 |     project = "analytics"
+                69 |   }
+                70 | }
+```
 4. `Заполните здесь этапы выполнения, если требуется ....`
 5. `Заполните здесь этапы выполнения, если требуется ....`
 6. 

--- a/vms/providers.tf
+++ b/vms/providers.tf
@@ -1,14 +1,4 @@
 
-# cat ~/.aws/config 
-# [default]
-# region=ru-central1
-# cat ~/.aws/credentials 
-# [default]
-# aws_access_key_id = YCAJEK...
-# aws_secret_access_key = YCMBzZ3...
-
-
-#For terraform >=1.6<=1.8.5
 terraform {
   required_version = ">= 1.8.4, < 2.0.0"
 


### PR DESCRIPTION
alexey@dell:~/team_terraform/vms$ tflint
2 issue(s) found:

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on main.tf line 5:
   5: data "template_file" "cloud_init" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.12.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "public_key" is declared but not used (terraform_unused_declarations)

  on variables.tf line 3:
   3: variable "public_key" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.12.0/docs/rules/terraform_unused_declarations.md

alexey@dell:~/team_terraform/vms$ checkov -d .
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml_outputs.tf
[ terraform framework ]: 100%|████████████████████|[4/4], Current File Scanned=variables.tf           
[ secrets framework ]: 100%|████████████████████|[5/5], Current File Scanned=./variables.tf           

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By Prisma Cloud | version: 3.2.441 

terraform scan results:

Passed checks: 2, Failed checks: 4, Skipped checks: 0

Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: yandex_compute_instance.vm_marketing
        File: /main.tf:12-40
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: yandex_compute_instance.vm_analytics
        File: /main.tf:42-70
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: yandex_compute_instance.vm_marketing
        File: /main.tf:12-40

                12 | resource "yandex_compute_instance" "vm_marketing" {
                13 |   name        = "vm-marketing"
                14 |   platform_id = "standard-v1"
                15 |   zone        = "ru-central1-a"  
                16 | 
                17 |   resources {
                18 |     cores  = 2
                19 |     memory = 2
                20 |   }
                21 | 
                22 |   boot_disk {
                23 |     initialize_params {
                24 |       image_id = var.image_id
                25 |     }
                26 |   }
                27 | 
                28 |   network_interface {
                29 |     subnet_id = var.subnet_id
                30 |     nat       = true
                31 |   }
                32 | 
                33 |   metadata = {
                34 |     user-data = data.template_file.cloud_init.rendered
                35 |   }
                36 | 
                37 |   labels = {
                38 |     project = "marketing"
                39 |   }
                40 | }

Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: yandex_compute_instance.vm_marketing
        File: /main.tf:12-40

                12 | resource "yandex_compute_instance" "vm_marketing" {
                13 |   name        = "vm-marketing"
                14 |   platform_id = "standard-v1"
                15 |   zone        = "ru-central1-a"  
                16 | 
                17 |   resources {
                18 |     cores  = 2
                19 |     memory = 2
                20 |   }
                21 | 
                22 |   boot_disk {
                23 |     initialize_params {
                24 |       image_id = var.image_id
                25 |     }
                26 |   }
                27 | 
                28 |   network_interface {
                29 |     subnet_id = var.subnet_id
                30 |     nat       = true
                31 |   }
                32 | 
                33 |   metadata = {
                34 |     user-data = data.template_file.cloud_init.rendered
                35 |   }
                36 | 
                37 |   labels = {
                38 |     project = "marketing"
                39 |   }
                40 | }

Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: yandex_compute_instance.vm_analytics
        File: /main.tf:42-70

                42 | resource "yandex_compute_instance" "vm_analytics" {
                43 |   name        = "vm-analytics"
                44 |   platform_id = "standard-v1"
                45 |   zone        = "ru-central1-a"
                46 | 
                47 |   resources {
                48 |     cores  = 2
                49 |     memory = 2
                50 |   }
                51 | 
                52 |   boot_disk {
                53 |     initialize_params {
                54 |       image_id = var.image_id
                55 |     }
                56 |   }
                57 | 
                58 |   network_interface {
                59 |     subnet_id = var.subnet_id
                60 |     nat       = true
                61 |   }
                62 | 
                63 |   metadata = {
                64 |     user-data = data.template_file.cloud_init.rendered
                65 |   }
                66 | 
                67 |   labels = {
                68 |     project = "analytics"
                69 |   }
                70 | }

Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: yandex_compute_instance.vm_analytics
        File: /main.tf:42-70

                42 | resource "yandex_compute_instance" "vm_analytics" {
                43 |   name        = "vm-analytics"
                44 |   platform_id = "standard-v1"
                45 |   zone        = "ru-central1-a"
                46 | 
                47 |   resources {
                48 |     cores  = 2
                49 |     memory = 2
                50 |   }
                51 | 
                52 |   boot_disk {
                53 |     initialize_params {
                54 |       image_id = var.image_id
                55 |     }
                56 |   }
                57 | 
                58 |   network_interface {
                59 |     subnet_id = var.subnet_id
                60 |     nat       = true
                61 |   }
                62 | 
                63 |   metadata = {
                64 |     user-data = data.template_file.cloud_init.rendered
                65 |   }
                66 | 
                67 |   labels = {
                68 |     project = "analytics"
                69 |   }
                70 | }


alexey@dell:~/team_terraform/vms$ erraform plan

Команда «erraform» не найдена. Возможно, вы имели в виду:

  command 'terraform' from snap terraform (1.12.2)

See 'snap info <snapname>' for additional versions.

alexey@dell:~/team_terraform/vms$ terraform plan
Acquiring state lock. This may take a few moments...
data.template_file.cloud_init: Reading...
data.template_file.cloud_init: Read complete after 0s [id=80502187d97e67c320c3b7f1946d42391842e1c438bf64d28cbc206cd07328dc]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # yandex_compute_instance.vm_analytics will be created
  + resource "yandex_compute_instance" "vm_analytics" {
      + created_at                = (known after apply)
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = (known after apply)
      + id                        = (known after apply)
      + labels                    = {
          + "project" = "analytics"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "user-data" = <<-EOT
                #cloud-config
                users:
                  - default
                  - name: ubuntu
                    ssh-authorized-keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM5m9AhMRWiO+yybLYEHaJhFaODFZDTbOiYqitAxzWgs alexey@dell
                
                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
                    shell: /bin/bash
                
                packages:
                  - nginx
            EOT
        }
      + name                      = "vm-analytics"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd8o5ddn529a6s8aldav"
              + name        = (known after apply)
              + size        = (known after apply)
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + metadata_options (known after apply)

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = "e9bns68ktbtv2kcec4o7"
        }

      + placement_policy (known after apply)

      + resources {
          + core_fraction = 100
          + cores         = 2
          + memory        = 2
        }

      + scheduling_policy (known after apply)
    }

  # yandex_compute_instance.vm_marketing will be created
  + resource "yandex_compute_instance" "vm_marketing" {
      + created_at                = (known after apply)
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = (known after apply)
      + id                        = (known after apply)
      + labels                    = {
          + "project" = "marketing"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "user-data" = <<-EOT
                #cloud-config
                users:
                  - default
                  - name: ubuntu
                    ssh-authorized-keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM5m9AhMRWiO+yybLYEHaJhFaODFZDTbOiYqitAxzWgs alexey@dell
                
                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
                    shell: /bin/bash
                
                packages:
                  - nginx
            EOT
        }
      + name                      = "vm-marketing"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd8o5ddn529a6s8aldav"
              + name        = (known after apply)
              + size        = (known after apply)
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + metadata_options (known after apply)

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = "e9bns68ktbtv2kcec4o7"
        }

      + placement_policy (known after apply)

      + resources {
          + core_fraction = 100
          + cores         = 2
          + memory        = 2
        }

      + scheduling_policy (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + analytics_vm_ip = (known after apply)
  + marketing_vm_ip = (known after apply)

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
alexey@dell:~/team_terraform/vms$ 